### PR TITLE
Fix error that occurs when a failing assertion tries to format the `_` (anything) matcher.

### DIFF
--- a/spec/formatters_spec.lua
+++ b/spec/formatters_spec.lua
@@ -175,6 +175,8 @@ describe("Test Formatters", function()
     local nostringformatted = assert:format({nostring, ["n"] = 1})[1]
     assert.is.same("(matcher) no.string()",
                    nostringformatted)
+    local anythingmatcherformatted = assert:format({match._, ["n"] = 1})[1]
+    assert.is.same("(matcher) _ *anything*", anythingmatcherformatted)
   end)
 
   it("checks arglist formatting", function()

--- a/spec/spies_spec.lua
+++ b/spec/spies_spec.lua
@@ -65,7 +65,18 @@ describe("Tests dealing with spies", function()
       .. "      %[1%] = 'test' } } }.\n"
       .. "Expected:\n"
       .. "%(values list%) %(%(number%) 5, %(number%) 6%)")
-  end)
+    -- assertion can format the `_` anything matcher appropriately in the fail message
+    assert.error_matches(
+      function() assert.spy(s).returned_with(5, _) end,
+      "Function never returned matching arguments.\n"
+      .. "Returned %(last call if any%):\n"
+      .. "%(values list%) %(%(table: 0x%x+%) {\n"
+      .. "  %[foo%] = {\n"
+      .. "    %[bar%] = {\n"
+      .. "      %[1%] = 'test' } } }.\n"
+      .. "Expected:\n"
+      .. "%(values list%) %(%(number%) 5, %(matcher%) _ %*anything%*%)")
+  end) -- (matcher) _ *anything*
 
   it("checks called() and called_with() assertions", function()
     local s = spy.new(function() end)
@@ -97,6 +108,17 @@ describe("Tests dealing with spies", function()
       .. "      %[1%] = 'test' } } }%)\n"
       .. "Expected:\n"
       .. "%(values list%) %(%(number%) 5, %(number%) 6%)")
+    -- assertion can format the `_` anything matcher appropriately in the fail message
+    assert.error_matches(
+      function() assert.spy(s).was.called_with(5, _) end,
+      "Function was never called with matching arguments.\n"
+      .. "Called with %(last call if any%):\n"
+      .. "%(values list%) %(%(table: 0x%x+%) {\n"
+      .. "  %[foo%] = {\n"
+      .. "    %[bar%] = {\n"
+      .. "      %[1%] = 'test' } } }%)\n"
+      .. "Expected:\n"
+      .. "%(values list%) %(%(number%) 5, %(matcher%) _ %*anything%*%)")
   end)
 
   it("checks called() and called_with() assertions using refs", function()

--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -221,7 +221,7 @@ local function fmt_matcher(arg)
   for idx = 1, arg.arguments.n do
     table.insert(args, assert:format({ arg.arguments[idx], n = 1, })[1])
   end
-  return string.format("(matcher) %s%s(%s)",
+  return string.format("(matcher) " .. (arg.name == "_" and "_ *anything*" or "%s%s(%s)"),
                        not_inverted[arg.mod],
                        tostring(arg.name),
                        table.concat(args, ", "))

--- a/src/match.lua
+++ b/src/match.lua
@@ -56,7 +56,12 @@ local state_mt = {
 }
 
 local match = {
-  _ = setmetatable({mod=true, callback=function() return true end}, matcher_mt),
+  _ = setmetatable({
+    name = "_",
+    mod = true,
+    callback = function() return true end,
+    arguments = { n = 0 },
+  }, matcher_mt),
 
   state = function() return setmetatable({mod=true, tokens={}}, state_mt) end,
 


### PR DESCRIPTION
Fixes #179

Cause the issue with:

 ```
   local test = spy.new(function() end)
   test('this', 39)
   assert.spy(test).called_with('that', match._)
```

Implementation: 
- Thought about using a custom formatter for the `_` matcher, but the order that the formatter is added to the list would be critical (it would have to be added after `assert:add_formatter(fmt_matcher)` in formatters/init.lua so it would be evaluated before fmt_matcher).  And it would be another formatter to cycle thru for all arguments formatted.  Plus it is a `matcher` after all and there already is a `fmt_matcher`
- Considered naming it `anything` and defining it like all the regular matchers.  But the regular matchers are intended to be called (e.g. `assert.spy(s).was.called_with(match.is_number())`) whereas match._ as shown in the README is not.  Plus it looks more like natural lua when used as is.
- Ultimately decided on a small change to `fmt_matcher` and a couple additional fields on match._ to make pass thru fmt_matcher without error.

Formatting:
-  I chose to display it in the assertion messages as ` _ *anything*` since `_` alone might confuse someone reading test results who hasn't used that matcher before.